### PR TITLE
Using the correct accumulated score for LeaderBoard

### DIFF
--- a/frontend/src/components/LeaderBoard.vue
+++ b/frontend/src/components/LeaderBoard.vue
@@ -61,7 +61,10 @@ export default {
             for (const p of this.players) {
                 let player = fixedData(p)
                 for (let day = 1; day < this.data.HighestDay + 1; day++) {
-                    const dataValue = p.LocalScoreAll.AccumulatedScore[day-1]
+                    let dataValue = p.LocalScoreActive.AccumulatedScore[day-1]
+                    if (this.$store.getters.includeZeroes) {
+                        dataValue = p.LocalScoreAll.AccumulatedScore[day-1]
+                    }
                     const starPositions = p.PositionForStar[day-1]
                     player[`d_${day}_0`] = dataValue[0] > -1 ? dataValue[0] : ""
                     player[`d_${day}_1`] = dataValue[1] > -1 ? dataValue[1] : ""


### PR DESCRIPTION
closes #3

When zero-achievers are included, the score is from LocalScoreAll.
If only active players are shown, LocalScoreActive is the source for
score.