### PR TITLE
F/issue 5

### DIFF
--- a/backend.net/RegenAoc.Tests/AocGeneratorTests.cs
+++ b/backend.net/RegenAoc.Tests/AocGeneratorTests.cs
@@ -31,6 +31,7 @@ namespace RegenAoc.Tests
         [TestCase(TestData.Guid1, 2020)]
         [TestCase(TestData.Guid1, 2017)]
         [TestCase(TestData.Guid2, 2020)]
+        [TestCase(TestData.Guid1, 2021)]
         public async Task TestGenerate(string id, int year)
         {
             var config = await BoardConfigHelper.LoadFromDynamo(id, year, Logger);

--- a/frontend/src/components/AccumulatedTimeToComplete.vue
+++ b/frontend/src/components/AccumulatedTimeToComplete.vue
@@ -55,7 +55,7 @@
 import InfoBlock from './InfoBlock.vue'
 import PositionCol from './PositionCol.vue'
 import ValueCol from './ValueCol.vue'
-import { fixedColumns, fixedData, dayColumns, secondsToString2 } from './tablehelpers'
+import { fixedColumns, fixedData, dayColumns, secondsToString2, decoratePlayerWithDayFields } from './tablehelpers'
 import TooltipHeader from './TooltipHeader.vue'
 import NameCol from './NameCol.vue'
 
@@ -91,11 +91,9 @@ export default {
                 let player = fixedData(p)
                 for (let day = 1; day < this.data.HighestDay + 1; day++) {
                     const dataValue = p.AccumulatedTimeToComplete[day-1]
-                    const starPositions = p.PositionForStar[day-1]
+                    decoratePlayerWithDayFields(player, p, day);
                     player[`d_${day}_0`] = dataValue[0] ? dataValue[0] : ""
                     player[`d_${day}_1`] = dataValue[1] ? dataValue[1] : ""
-                    player[`s_${day}_0`] = starPositions[0]
-                    player[`s_${day}_1`] = starPositions[1]
                 }
                 res.push(player)
             }

--- a/frontend/src/components/CompletionTime.vue
+++ b/frontend/src/components/CompletionTime.vue
@@ -56,7 +56,7 @@
 import InfoBlock from './InfoBlock.vue'
 import PositionCol from './PositionCol.vue'
 import ValueCol from './ValueCol.vue'
-import { fixedColumns, fixedData, dayColumns, secondsToString } from './tablehelpers'
+import { fixedColumns, fixedData, dayColumns, secondsToString, decoratePlayerWithDayFields } from './tablehelpers'
 import TooltipHeader from './TooltipHeader.vue'
 import NameCol from './NameCol.vue'
 
@@ -90,12 +90,10 @@ export default {
             for (const p of this.players) {
                 let player = fixedData(p)
                 for (let day = 1; day < this.data.HighestDay + 1; day++) {
+                    decoratePlayerWithDayFields(player, p, day);
                     const dataValue = p.TimeToComplete[day-1]
-                    const starPositions = p.PositionForStar[day-1]
                     player[`d_${day}_0`] = dataValue[0] !== -1 ? dataValue[0] : Number.MAX_SAFE_INTEGER
                     player[`d_${day}_1`] = dataValue[1] !== -1 ? dataValue[1] : Number.MAX_SAFE_INTEGER
-                    player[`s_${day}_0`] = starPositions[0]
-                    player[`s_${day}_1`] = starPositions[1]
                 }
                 res.push(player)
             }

--- a/frontend/src/components/CompletionTimeStarTwo.vue
+++ b/frontend/src/components/CompletionTimeStarTwo.vue
@@ -57,7 +57,7 @@
 import InfoBlock from './InfoBlock.vue'
 import PositionCol from './PositionCol.vue'
 import ValueCol from './ValueCol.vue'
-import { fixedColumns, fixedData, secondsToString } from './tablehelpers'
+import { fixedColumns, fixedData, secondsToString, decoratePlayerWithDayFields } from './tablehelpers'
 import TooltipHeader from './TooltipHeader.vue'
 import NameCol from './NameCol.vue'
 
@@ -65,7 +65,7 @@ export default {
     components: { InfoBlock, PositionCol, ValueCol, TooltipHeader, NameCol },
     data() { return {
         infoTitle: "Completion Time Star 2",
-        infotext: "This board shows the time to complete second star after completing the first."
+        infotext: "This board shows the time to complete second star after completing the first. The medal color is calculated by comparing the time from *1 to *2."
     }},
     methods: {
         getValue(item, key) {
@@ -97,6 +97,7 @@ export default {
                 for (let day = 1; day < this.data.HighestDay + 1; day++) {
                     const dataValue = p.TimeToCompleteStar2[day-1]
                     const starPositions = p.PositionStar2[day-1]
+                    decoratePlayerWithDayFields(player, p, day);
                     player[`d_${day}_0`] = dataValue !== -1 ? dataValue : Number.MAX_SAFE_INTEGER
                     player[`s_${day}_0`] = starPositions
                 }

--- a/frontend/src/components/GlobalScoreForDay.vue
+++ b/frontend/src/components/GlobalScoreForDay.vue
@@ -56,7 +56,7 @@
 import InfoBlock from './InfoBlock.vue'
 import PositionCol from './PositionCol.vue'
 import ValueCol from './ValueCol.vue'
-import { fixedColumns, fixedData, dayColumns } from './tablehelpers'
+import { fixedColumns, fixedData, dayColumns, decoratePlayerWithDayFields } from './tablehelpers'
 import TooltipHeader from './TooltipHeader.vue'
 import NameCol from './NameCol.vue'
 
@@ -93,6 +93,7 @@ export default {
                     const starPositions = p.PositionForStar[day-1]
                     let globalValue = 99
                     if (p.GlobalScoreForDay[day-1] > 0) { globalValue = 0}
+                    decoratePlayerWithDayFields(player, p, day);
                     player[`d_${day}_0`] = dataValue[0] == 0 ? "" : dataValue[0]
                     player[`d_${day}_1`] = dataValue[1] == 0 ? "" : dataValue[1]
                     player[`s_${day}_0`] = starPositions[0] + globalValue

--- a/frontend/src/components/LeaderBoard.vue
+++ b/frontend/src/components/LeaderBoard.vue
@@ -54,7 +54,7 @@
 import InfoBlock from './InfoBlock.vue'
 import PositionCol from './PositionCol.vue'
 import ValueCol from './ValueCol.vue'
-import { fixedColumns, fixedData, dayColumns } from './tablehelpers'
+import { fixedColumns, fixedData, dayColumns, decoratePlayerWithDayFields } from './tablehelpers'
 import TooltipHeader from './TooltipHeader.vue'
 import NameCol from './NameCol.vue'
 
@@ -96,11 +96,9 @@ export default {
                     if (this.$store.getters.includeZeroes) {
                         dataValue = p.LocalScoreAll.AccumulatedPosition[day-1]
                     }
-                    const starPositions = p.PositionForStar[day-1]
+                    decoratePlayerWithDayFields(player, p, day);
                     player[`d_${day}_0`] = dataValue[0] > -1 ? dataValue[0] : ""
                     player[`d_${day}_1`] = dataValue[1] > -1 ? dataValue[1] : ""
-                    player[`s_${day}_0`] = starPositions[0]
-                    player[`s_${day}_1`] = starPositions[1]
                 }
                 res.push(player)
             }

--- a/frontend/src/components/LeaderBoard.vue
+++ b/frontend/src/components/LeaderBoard.vue
@@ -62,7 +62,9 @@ export default {
     components: { InfoBlock, PositionCol, ValueCol, TooltipHeader, NameCol },
     data() { return {
         infoTitle: "Leaderboard",
-        infotext: "This board shows the <h1>leaders</h1> and points per day."
+        infotext: "This board shows the accummulated position of each player. <br>" +
+            "The ordering is based on the official AoC 'local score' where the winner each day receives the same number of points as players on the list, but only results up to that day/star is considered.<br>"+
+            "The 'medal color' shows the top three players for each day/star"
     }},
     methods: {
         getValue(item, key) {
@@ -90,9 +92,9 @@ export default {
             for (const p of this.players) {
                 let player = fixedData(p)
                 for (let day = 1; day < this.data.HighestDay + 1; day++) {
-                    let dataValue = p.LocalScoreActive.AccumulatedScore[day-1]
+                    let dataValue = p.LocalScoreActive.AccumulatedPosition[day-1]
                     if (this.$store.getters.includeZeroes) {
-                        dataValue = p.LocalScoreAll.AccumulatedScore[day-1]
+                        dataValue = p.LocalScoreAll.AccumulatedPosition[day-1]
                     }
                     const starPositions = p.PositionForStar[day-1]
                     player[`d_${day}_0`] = dataValue[0] > -1 ? dataValue[0] : ""

--- a/frontend/src/components/OffsetFromWinner.vue
+++ b/frontend/src/components/OffsetFromWinner.vue
@@ -56,7 +56,7 @@
 import InfoBlock from './InfoBlock.vue'
 import PositionCol from './PositionCol.vue'
 import ValueCol from './ValueCol.vue'
-import { fixedColumns, fixedData, dayColumns, secondsToString } from './tablehelpers'
+import { fixedColumns, fixedData, dayColumns, secondsToString, decoratePlayerWithDayFields } from './tablehelpers'
 import TooltipHeader from './TooltipHeader.vue'
 import NameCol from './NameCol.vue'
 
@@ -94,12 +94,10 @@ export default {
             for (const p of this.players) {
                 let player = fixedData(p)
                 for (let day = 1; day < this.data.HighestDay + 1; day++) {
+                    decoratePlayerWithDayFields(player, p, day);
                     const dataValue = p.OffsetFromWinner[day-1]
-                    const starPositions = p.PositionForStar[day-1]
                     player[`d_${day}_0`] = dataValue[0] !== -1 ? dataValue[0] : Number.MAX_SAFE_INTEGER
                     player[`d_${day}_1`] = dataValue[1] !== -1 ? dataValue[1] : Number.MAX_SAFE_INTEGER
-                    player[`s_${day}_0`] = starPositions[0]
-                    player[`s_${day}_1`] = starPositions[1]
                 }
                 res.push(player)
             }

--- a/frontend/src/components/PositionForStar.vue
+++ b/frontend/src/components/PositionForStar.vue
@@ -56,7 +56,7 @@
 import InfoBlock from './InfoBlock.vue'
 import PositionCol from './PositionCol.vue'
 import ValueColMedal from './ValueColMedal.vue'
-import { fixedColumns, fixedData, dayColumns } from './tablehelpers'
+import { fixedColumns, fixedData, dayColumns, decoratePlayerWithDayFields } from './tablehelpers'
 import TooltipHeader from './TooltipHeader.vue'
 import NameCol from './NameCol.vue'
 
@@ -94,11 +94,9 @@ export default {
                 let player = fixedData(p)
                 for (let day = 1; day < this.data.HighestDay + 1; day++) {
                     const dataValue = p.PositionForStar[day-1]
-                    const starPositions = p.PositionForStar[day-1]
+                    decoratePlayerWithDayFields(player, p, day);
                     player[`d_${day}_0`] = dataValue[0]
                     player[`d_${day}_1`] = dataValue[1]
-                    player[`s_${day}_0`] = starPositions[0]
-                    player[`s_${day}_1`] = starPositions[1]
                 }
                 res.push(player)
             }

--- a/frontend/src/components/TobiiScore.vue
+++ b/frontend/src/components/TobiiScore.vue
@@ -54,7 +54,7 @@
 import InfoBlock from './InfoBlock.vue'
 import PositionCol from './PositionCol.vue'
 import ValueCol from './ValueCol.vue'
-import { fixedColumns, fixedData, dayColumns } from './tablehelpers'
+import { fixedColumns, fixedData, dayColumns, decoratePlayerWithDayFields } from './tablehelpers'
 import TooltipHeader from './TooltipHeader.vue'
 import NameCol from './NameCol.vue'
 
@@ -97,11 +97,9 @@ export default {
                 let player = fixedData(p)
                 for (let day = 1; day < this.data.HighestDay + 1; day++) {
                     const dataValue = p.TobiiScore.AccumulatedPosition[day-1]
-                    const starPositions = p.PositionForStar[day-1]
+                    decoratePlayerWithDayFields(player, p, day);
                     player[`d_${day}_0`] = dataValue[0] > -1 ? dataValue[0] : ""
                     player[`d_${day}_1`] = dataValue[1] > -1 ? dataValue[1] : ""
-                    player[`s_${day}_0`] = starPositions[0]
-                    player[`s_${day}_1`] = starPositions[1]
                 }
                 res.push(player)
             }

--- a/frontend/src/components/ValueCol.vue
+++ b/frontend/src/components/ValueCol.vue
@@ -3,18 +3,21 @@
             <template v-slot:activator="{ on, attrs }">
                 <span v-bind="attrs" v-on="on" v-bind:class="medalColor(item)">{{ getValue(item, header) }}</span>
             </template>
-            <span>{{item.name}}</span>
+            <span>{{item.name}}<br>*1: {{ solveTime(item, 0) }}<br>*2: {{ solveTime(item, 1) }}</span>
         </v-tooltip>
 </template>
 
 <script>
-import { getMedalColor } from './tablehelpers'
+import { getMedalColor, getSolveTime } from './tablehelpers'
 
 export default {
     props: ["item", "header", "getValue"],
     methods: {
         medalColor(item) {
             return getMedalColor(item, this.header)
+        },
+        solveTime(item, star) {
+            return getSolveTime(item, this.header, star)
         },
     }
 }

--- a/frontend/src/components/tablehelpers.js
+++ b/frontend/src/components/tablehelpers.js
@@ -53,6 +53,21 @@ export function getMedalColor(item, key) {
     return  medal + excluded
 }
 
+export function getSolveTime(item, key, star) {
+    const posKey = "t_" + key.slice(2, -2)+"_"+star;
+    const res = secondsToString(item[posKey]);
+    return  res
+}
+
+export function decoratePlayerWithDayFields(player, p, day) {
+    player[`s_${day}_0`] = p.PositionForStar[day-1][0]
+    player[`s_${day}_1`] = p.PositionForStar[day-1][1]
+
+    player[`t_${day}_0`] = p.TimeToComplete[day-1][0]
+    player[`t_${day}_1`] = p.TimeToComplete[day-1][1]
+}
+
+
 const secondsInHour = 60 * 60
 const secondsInDay = secondsInHour * 24
 


### PR DESCRIPTION
Fixes #5 by changing the leaderboard to always show the accumulated position rather than the accumulated score (since that isn't quite as useful. 
Also adds fly over hints with completion time for each star.